### PR TITLE
🚀 Winget Compatibility

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
 
-Fixes # (issue)
+- Fixes # (issue)
 
 ## Type of change
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release 🚀
+
+on:
+  push:
+    tags:
+      - "*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    name: GoReleaser 🚀
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go 🐹
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+
+      - name: Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4 # v6.1.0
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
+
+      - name: Run GoReleaser 🚀
+        uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,4 +1,4 @@
-version: 1
+project_name: ScrumChrono
 
 before:
   hooks:
@@ -6,12 +6,21 @@ before:
     - go mod download
     - go generate ./...
 
+env:
+  - CGO_ENABLED=0
+
 builds:
   - env:
       - CGO_ENABLED=0
     main: ./main.go
-
-    binary: ScrumChrono
+    goos:
+      - linux
+      - windows
+      - darwin
+    ldflags:
+          - -s -w -X main.version={{.Version}}
+          - -s -w -X main.commit={{.ShortCommit}}
+          - -s -w -X main.Date={{.CommitDate}}
 
 archives:
   - format: tar.gz
@@ -70,4 +79,5 @@ winget:
       - Scrum
       - Terminal
 
-    
+snapshot:
+  name_template: "{{ .Tag }}-next"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,17 +10,15 @@ env:
   - CGO_ENABLED=0
 
 builds:
-  - env:
-      - CGO_ENABLED=0
-    main: ./main.go
-    goos:
-      - linux
-      - windows
-      - darwin
-    ldflags:
-          - -s -w -X cmd.version={{.Version}}
-          - -s -w -X cmd.commit={{.ShortCommit}}
-          - -s -w -X cmd.date={{.CommitDate}}
+   -  main: ./main.go
+      goos:
+        - linux
+        - windows
+        - darwin
+      ldflags:
+        - -s -w -X cmd.Version={{.Version}}
+        - -s -w -X cmd.Commit={{.ShortCommit}}
+        - -s -w -X cmd.Date={{.CommitDate}}
 
 archives:
   - format: tar.gz

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,9 +16,9 @@ builds:
         - windows
         - darwin
       ldflags:
-        - -s -w -X cmd.Version={{.Version}}
-        - -s -w -X cmd.Commit={{.ShortCommit}}
-        - -s -w -X cmd.Date={{.CommitDate}}
+        - -s -w -X github.com/pedrojreis/ScrumChrono/cmd.Version={{.Version}}
+        - -s -w -X github.com/pedrojreis/ScrumChrono/cmd.Commit={{.ShortCommit}}
+        - -s -w -X github.com/pedrojreis/ScrumChrono/cmd.Date={{.CommitDate}}
 
 archives:
   - format: tar.gz

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,9 +18,9 @@ builds:
       - windows
       - darwin
     ldflags:
-          - -s -w -X main.version={{.Version}}
-          - -s -w -X main.commit={{.ShortCommit}}
-          - -s -w -X main.Date={{.CommitDate}}
+          - -s -w -X cmd.version={{.Version}}
+          - -s -w -X cmd.commit={{.ShortCommit}}
+          - -s -w -X cmd.date={{.CommitDate}}
 
 archives:
   - format: tar.gz

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -38,6 +38,9 @@ archives:
       - README.md
       - config.yaml
 
+signs:
+  - artifacts: all
+
 changelog:
   sort: asc
   filters:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,8 @@ import (
 )
 
 var (
+	Version, ShortCommit, CommitDate string
+
 	rootCmd = &cobra.Command{
 		Use:   "ScrumChrono",
 		Short: "ScrumChrono is a simple CLI tool to manage the time of each member of a team during a Scrum meeting.",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	Version, ShortCommit, CommitDate string
+	version, commit, date string
 
 	rootCmd = &cobra.Command{
 		Use:   "ScrumChrono",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,7 +16,9 @@ import (
 )
 
 var (
-	version, commit, date string
+	Version string = "dev"
+	Commit  string
+	Date    string
 
 	rootCmd = &cobra.Command{
 		Use:   "ScrumChrono",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,12 +1,13 @@
 package cmd
 
 import (
-	"ScrumChrono/core"
-	"ScrumChrono/core/jira"
 	"fmt"
 	"log"
 	"strings"
 	"time"
+
+	"github.com/pedrojreis/ScrumChrono/core"
+	"github.com/pedrojreis/ScrumChrono/core/jira"
 
 	"github.com/common-nighthawk/go-figure"
 	"github.com/gizak/termui/v3"

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -16,9 +16,9 @@ func versionCmd() *cobra.Command {
 			d := color.New(color.FgHiBlue)
 			d.Print(figure.NewFigure("Scrum Chrono", "speed", true).String())
 			d.Println()
-			d.Println("Version ", version)
-			d.Println("Commit ", commit)
-			d.Println("Date ", date)
+			d.Println("Version ", Version)
+			d.Println("Commit ", Commit)
+			d.Println("Date ", Date)
 		},
 	}
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -16,9 +16,9 @@ func versionCmd() *cobra.Command {
 			d := color.New(color.FgHiBlue)
 			d.Print(figure.NewFigure("Scrum Chrono", "speed", true).String())
 			d.Println()
-			d.Println("Version ", Version)
-			d.Println("Commit ", ShortCommit)
-			d.Println("Date ", CommitDate)
+			d.Println("Version ", version)
+			d.Println("Commit ", commit)
+			d.Println("Date ", date)
 		},
 	}
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,8 +6,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const Version = "0.1.2"
-
 func versionCmd() *cobra.Command {
 
 	command := cobra.Command{
@@ -19,6 +17,8 @@ func versionCmd() *cobra.Command {
 			d.Print(figure.NewFigure("Scrum Chrono", "speed", true).String())
 			d.Println()
 			d.Println("Version ", Version)
+			d.Println("Commit ", ShortCommit)
+			d.Println("Date ", CommitDate)
 		},
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module ScrumChrono
+module github.com/pedrojreis/ScrumChrono
 
 go 1.21.7
 

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"ScrumChrono/cmd"
+	"github.com/pedrojreis/ScrumChrono/cmd"
 )
 
 func main() {


### PR DESCRIPTION
# Description

This PR intends to add: 
- WinGet release capabilities.
- We no longer need to edit or bump version 🥳
- Also our `version` command now gets additional information
- GHA to Automatically Release Tap & Winget on Tag

![image](https://github.com/pedrojreis/ScrumChrono/assets/28795057/948f05aa-ec41-4228-8529-4ddb598e8ea5)


- Fixes #8 
- Fixes #5 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)