### PR TITLE
👔 Added Orange color for the last third of the timer

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -153,6 +153,9 @@ func startCountdown() {
 				case int(timers[currentPerson]/time.Second) < (maxTime * 2 / 3):
 					countdown.TextStyle = termui.NewStyle(termui.ColorYellow)
 					countdown.BorderStyle = termui.NewStyle(termui.ColorYellow)
+				case int(timers[currentPerson]/time.Second) < (maxTime):
+					countdown.TextStyle = termui.NewStyle(termui.Color(202))
+					countdown.BorderStyle = termui.NewStyle(termui.Color(202))
 				default:
 					countdown.TextStyle = termui.NewStyle(termui.ColorRed)
 					countdown.BorderStyle = termui.NewStyle(termui.ColorRed)


### PR DESCRIPTION
# Description

This PR changes the way colouring works, it adds another color when timer is ticking.

For a 3 minute timer (internally all works based on percentage):
- from 00:00 to 00:59 = Green (0%)

![image](https://github.com/pedrojreis/ScrumChrono/assets/28795057/4150fe7d-72fa-45cf-b14f-7429784569f4)

- from 1:00 to 1:59 = Yellow (33%)

![image](https://github.com/pedrojreis/ScrumChrono/assets/28795057/8050fd38-6490-427a-97a5-1d0b3e49812a)


- from 2:00 to 2:59 = Orange (66%)

![image](https://github.com/pedrojreis/ScrumChrono/assets/28795057/6f7afe4a-acb9-4bd8-bda8-6281b578b10c)


- From 3:00 = Red (100%+)

![image](https://github.com/pedrojreis/ScrumChrono/assets/28795057/abc5ba2b-7ef9-4f81-9940-63c79e7de540)


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)